### PR TITLE
Status.Ready

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/sveltoscluster-manager:main
+      - image: projectsveltos/sveltoscluster-manager:dev
         name: manager

--- a/controllers/sveltoscluster_controller.go
+++ b/controllers/sveltoscluster_controller.go
@@ -144,7 +144,6 @@ func (r *SveltosClusterReconciler) reconcileNormal(
 	if err := clientgoscheme.AddToScheme(s); err != nil {
 		errorMessage := err.Error()
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get scheme: %v", err))
-		sveltosClusterScope.SveltosCluster.Status.Ready = false
 		sveltosClusterScope.SveltosCluster.Status.FailureMessage = &errorMessage
 		return
 	}
@@ -155,7 +154,6 @@ func (r *SveltosClusterReconciler) reconcileNormal(
 	if err != nil {
 		errorMessage := err.Error()
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get client: %v", err))
-		sveltosClusterScope.SveltosCluster.Status.Ready = false
 		sveltosClusterScope.SveltosCluster.Status.FailureMessage = &errorMessage
 		return
 	}
@@ -166,7 +164,6 @@ func (r *SveltosClusterReconciler) reconcileNormal(
 	if err != nil {
 		errorMessage := err.Error()
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get client: %v", err))
-		sveltosClusterScope.SveltosCluster.Status.Ready = false
 		sveltosClusterScope.SveltosCluster.Status.FailureMessage = &errorMessage
 		return
 	}
@@ -180,7 +177,6 @@ func (r *SveltosClusterReconciler) reconcileNormal(
 	if err != nil && !apierrors.IsNotFound(err) {
 		errorMessage := err.Error()
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get projectsveltos namespace: %v", err))
-		sveltosClusterScope.SveltosCluster.Status.Ready = false
 		sveltosClusterScope.SveltosCluster.Status.FailureMessage = &errorMessage
 	} else {
 		currentVersion, err := utils.GetKubernetesVersion(ctx, config, logger)

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,7 +24,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: projectsveltos/sveltoscluster-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -103,7 +103,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: projectsveltos/sveltoscluster-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Status.Ready will be set to true first time sveltoscluster controller can reach the managed cluster.
Once set to true, `Status.Ready` will never be set to false again.

If an error occurs connecting to the managed cluster, the error will be reported in the `Status.FailureMessage` field and `Status.Ready` will continue to stay set to true.

For instance

```
  status:
    failureMessage: 'failed to get API group resources: unable to retrieve the complete
      list of server APIs: v1: Get "https://212.2.243.209:6443/api/v1": dial tcp 212.2.243.209:6443:
      i/o timeout'
    ready: true
    version: v1.29.2+k3s1
```

This means Ready indicates that at least once the cluster was reachable.

Before this PR a temporary network connectivity issue had bad effect:

1. Sveltoscluster controller could not temporarily reach the managed cluster => set Status.Ready to false
2. Sveltos addon-controller reacted a Ready=false cluster by considering it a non match => all clusterSummaries corresponding to such a cluster deleted
3. A deleted ClusterSummary removes all deployed add-ons and applications from the cluster

With this PR, above does not happen anymore.
A temporary network connectivity issue simply causes SveltoCluster controller to set `FailureMessage`. No more point 2 and 3.

Closes #209 