### PR TITLE
feat: relay the sveltos license onto SveltosCluster for pull-mode agents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.13.0
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -117,6 +117,7 @@ func main() {
 		Scheme:               mgr.GetScheme(),
 		ConcurrentReconciles: concurrentReconciles,
 		ShardKey:             shardKey,
+		SveltosNamespace:     sveltosNamespace,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SveltosCluster")
 		os.Exit(1)

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/sveltoscluster-manager:v1.13.0
+      - image: docker.io/projectsveltos/sveltoscluster-manager:main
         name: manager

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -22,6 +22,7 @@ var (
 	AdjustTokenRequestRenewalOption = (*SveltosClusterReconciler).adjustTokenRequestRenewalOption
 	GetServiceAccountTokenRequest   = (*SveltosClusterReconciler).getServiceAccountTokenRequest
 	ReconcilePullModeCluster        = (*SveltosClusterReconciler).reconcilePullModeCluster
+	UpdateLicenseAnnotations        = (*SveltosClusterReconciler).updateLicenseAnnotations
 )
 
 var (

--- a/controllers/sveltoscluster_controller.go
+++ b/controllers/sveltoscluster_controller.go
@@ -46,6 +46,7 @@ import (
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
+	license "github.com/projectsveltos/libsveltos/lib/licenses"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/pullmode"
 	"github.com/projectsveltos/libsveltos/lib/sharding"
@@ -67,6 +68,7 @@ type SveltosClusterReconciler struct {
 	Scheme               *runtime.Scheme
 	ConcurrentReconciles int
 	ShardKey             string // when set, only clusters matching the ShardKey will be reconciled
+	SveltosNamespace     string // namespace holding the sveltos-license Secret
 }
 
 type matchStatus struct {
@@ -158,7 +160,7 @@ func (r *SveltosClusterReconciler) reconcileNormal(
 	defer handleAutomaticPauseUnPause(sveltosClusterScope.SveltosCluster, time.Now(), logger)
 
 	if sveltosClusterScope.SveltosCluster.Spec.PullMode {
-		r.reconcilePullModeCluster(sveltosClusterScope, logger)
+		r.reconcilePullModeCluster(ctx, sveltosClusterScope, logger)
 		return
 	}
 
@@ -679,10 +681,16 @@ func (r *SveltosClusterReconciler) runChecks(ctx context.Context, remotConfig *r
 }
 
 func (r *SveltosClusterReconciler) reconcilePullModeCluster(
-	sveltosClusterScope *scope.SveltosClusterScope, logger logr.Logger,
+	ctx context.Context, sveltosClusterScope *scope.SveltosClusterScope, logger logr.Logger,
 ) {
 
 	cluster := sveltosClusterScope.SveltosCluster
+
+	// Relay the license so sveltos-applier (which cannot reach the sveltos-license Secret
+	// directly) can independently verify it. Runs regardless of agent connectivity, so a
+	// license change is visible even while the agent is unreachable.
+	r.updateLicenseAnnotations(ctx, cluster, logger)
+
 	if !cluster.Status.Ready {
 		return
 	}
@@ -711,6 +719,65 @@ func (r *SveltosClusterReconciler) reconcilePullModeCluster(
 	updateConnectionFailuresMetric(string(libsveltosv1beta1.ClusterTypeSveltos),
 		sveltosClusterScope.SveltosCluster.Namespace, sveltosClusterScope.SveltosCluster.Name,
 		sveltosClusterScope.SveltosCluster.Status.ConnectionFailures, logger)
+}
+
+// updateLicenseAnnotations relays the sveltos-license Secret's payload/signature bytes
+// (base64-encoded) onto the SveltosCluster, since sveltos-applier cannot reach that Secret
+// directly (it lives in a different namespace than sveltos-applier's constrained RBAC
+// covers). sveltos-applier independently re-verifies the signature itself; this only
+// transports the bytes, it does not assert validity.
+//
+// The annotations are set whenever the signature verifies, even if the license itself is
+// expired, so sveltos-applier can distinguish "a license is present but expired" from
+// "no license at all". They are cleared when no signed payload could be extracted (missing
+// Secret, missing keys, or a signature that doesn't verify).
+//
+// This runs every minute (the pull-mode reconcile cadence), but the license itself changes
+// rarely. cluster.Annotations is only mutated when the value actually differs from what's
+// already there, so an unchanged license produces no diff for the scope's patch helper to
+// persist, and no SveltosCluster watch event fires — other components (e.g. addon-controller)
+// watch SveltosCluster to trigger their own reconciliation, and shouldn't be woken up every
+// minute for a no-op.
+func (r *SveltosClusterReconciler) updateLicenseAnnotations(ctx context.Context,
+	cluster *libsveltosv1beta1.SveltosCluster, logger logr.Logger) {
+
+	publicKey, err := license.GetPublicKey()
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get license public key: %v", err))
+		return
+	}
+
+	result := license.VerifyLicenseSecret(ctx, r.Client, r.SveltosNamespace, publicKey, logger)
+
+	if result.PayloadData == nil {
+		if cluster.Annotations == nil {
+			return
+		}
+		_, hasPayload := cluster.Annotations[license.LicensePayloadAnnotation]
+		_, hasSignature := cluster.Annotations[license.LicenseSignatureAnnotation]
+		if !hasPayload && !hasSignature {
+			return
+		}
+		delete(cluster.Annotations, license.LicensePayloadAnnotation)
+		delete(cluster.Annotations, license.LicenseSignatureAnnotation)
+		return
+	}
+
+	payloadAnnotation := base64.StdEncoding.EncodeToString(result.PayloadData)
+	signatureAnnotation := base64.StdEncoding.EncodeToString(result.SignatureData)
+
+	if cluster.Annotations != nil &&
+		cluster.Annotations[license.LicensePayloadAnnotation] == payloadAnnotation &&
+		cluster.Annotations[license.LicenseSignatureAnnotation] == signatureAnnotation {
+
+		return
+	}
+
+	if cluster.Annotations == nil {
+		cluster.Annotations = map[string]string{}
+	}
+	cluster.Annotations[license.LicensePayloadAnnotation] = payloadAnnotation
+	cluster.Annotations[license.LicenseSignatureAnnotation] = signatureAnnotation
 }
 
 // serviceAccountInfo holds the parsed ServiceAccount details

--- a/controllers/sveltoscluster_controller_test.go
+++ b/controllers/sveltoscluster_controller_test.go
@@ -485,7 +485,7 @@ var _ = Describe("SveltosCluster: Reconciler", func() {
 		})
 		Expect(err).To(BeNil())
 
-		controllers.ReconcilePullModeCluster(reconciler, sveltosClusterScope, logger)
+		controllers.ReconcilePullModeCluster(reconciler, context.TODO(), sveltosClusterScope, logger)
 
 		Expect(currentSveltosCluster.Status.FailureMessage).To(BeNil())
 		Expect(currentSveltosCluster.Status.ConnectionStatus).To(Equal(libsveltosv1beta1.ConnectionHealthy))
@@ -509,7 +509,7 @@ var _ = Describe("SveltosCluster: Reconciler", func() {
 			return age > 5*time.Minute
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		controllers.ReconcilePullModeCluster(reconciler, sveltosClusterScope, logger)
+		controllers.ReconcilePullModeCluster(reconciler, context.TODO(), sveltosClusterScope, logger)
 
 		Expect(currentSveltosCluster.Status.FailureMessage).ToNot(BeNil())
 	})

--- a/controllers/sveltoscluster_license_test.go
+++ b/controllers/sveltoscluster_license_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//nolint:lll // this file has long lines due to signed licenses
+package controllers_test
+
+import (
+	"context"
+	"encoding/base64"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	license "github.com/projectsveltos/libsveltos/lib/licenses"
+	"github.com/projectsveltos/sveltoscluster-manager/controllers"
+)
+
+// validLicenseDataB64 / validLicenseSignatureB64 are the licenseData/licenseSignature values
+// of a valid, non-expired license (Enterprise plan, PullMode feature, MaxClusters 1).
+const (
+	validLicenseDataB64      = "eyJpZCI6IjdmNDU0Mjk4LWUyYjItNDFhOC05MWRjLTc4ZjU5MjE4Nzk5MiIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwicGxhbiI6IkVudGVycHJpc2UiLCJleHBpcmF0aW9uRGF0ZSI6IjIwMjctMDctMjZUMTM6NDc6MzEuODUyMjE2WiIsImdyYWNlUGVyaW9kRGF5cyI6NywibWF4Q2x1c3RlcnMiOjEsImlzc3VlZEF0IjoiMjAyNi0wNy0yNlQxMzo0NzozMS44NTIyMTZaIn0="
+	validLicenseSignatureB64 = "BjYc6SDAcfrj4rBc4Fi0LfcdkU5qtAEojunwFV/0Llpsgx+IYi+XDyiq6VhZFDGl24tMcKOSHyPoTA3/5s5IIeZVpDRSd2+BXXFd9ccBScfyKRzDlO8Cg5rs0ejNwzrJKTNPxjorB7WxB3WK7ad6hbrmU6/PI6vdER7XjPsb3BuaDpzA5Z3wiuoyzB+BFJ9fbeVSDL2XxaZ+M/ifaM8/bGKsj7dUXwrP+ArNouObikxBsJsqZ9n1mgQx6WZm8fJOxct79Qmva1ys4O8QcP4MYY6rsbfag0xshpKKaZKMO10XugqtDYWz14pDV9vMKWEM0jMa4oHZmebMd4Wq+F/tB+GVIyYU8aWroYVKU5kkWFdFOcQozdNmyyLOn1umdJd2JouEWkcDHIRKfA1TpIfwaeKHB6JjW5WpKzbFfnrZUW9LWVOSegmv/HpgvXMiAXUyvVlhPHArPjBJyKhb5FNcb2kaYAk8ouFv/ydhFFcerTJMWp7bqkeLWlgMfUtw/oC0GKBLM090ovCkYAeaxjgWqm9sHVJCTFGeeqh2hff98UfAoQ5g9R9mP8e1rXNtWtdWK2UIaxcwymTKS7RNe2K3TpVORE4ESuOpSJMjUut7w2oAo1O7C2ZAlfoTi4JQmqBU9S+XG4AoEBkFPPbIlA8ak0xZU9Hh3Ony7WGr59tmkOU="
+
+	staleAnnotationValue = "stale"
+)
+
+func newLicenseSecret(namespace string, payloadData, signatureData []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "sveltos-license",
+		},
+		Data: map[string][]byte{
+			"licenseData":      payloadData,
+			"licenseSignature": signatureData,
+		},
+	}
+}
+
+var _ = Describe("SveltosCluster: updateLicenseAnnotations", func() {
+	var licenseNamespace string
+	var sveltosCluster *libsveltosv1beta1.SveltosCluster
+	var logger logr.Logger
+	var payloadData, signatureData []byte
+
+	BeforeEach(func() {
+		var err error
+		payloadData, err = base64.StdEncoding.DecodeString(validLicenseDataB64)
+		Expect(err).To(BeNil())
+		signatureData, err = base64.StdEncoding.DecodeString(validLicenseSignatureB64)
+		Expect(err).To(BeNil())
+
+		licenseNamespace = randomString()
+		sveltosCluster = getSveltosClusterInstance(randomString(), randomString())
+		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+	})
+
+	It("sets payload/signature annotations when a valid license is found", func() {
+		secret := newLicenseSecret(licenseNamespace, payloadData, signatureData)
+		c := fake.NewClientBuilder().WithObjects(secret).Build()
+		reconciler := &controllers.SveltosClusterReconciler{
+			Client:           c,
+			Scheme:           scheme,
+			SveltosNamespace: licenseNamespace,
+		}
+
+		controllers.UpdateLicenseAnnotations(reconciler, context.TODO(), sveltosCluster, logger)
+
+		Expect(sveltosCluster.Annotations[license.LicensePayloadAnnotation]).To(Equal(validLicenseDataB64))
+		Expect(sveltosCluster.Annotations[license.LicenseSignatureAnnotation]).To(Equal(validLicenseSignatureB64))
+	})
+
+	It("relays an expired-but-validly-signed license too, so sveltos-applier can tell present-but-expired apart from absent", func() {
+		expiredPayload, err := base64.StdEncoding.DecodeString(
+			"eyJpZCI6IjY0Mzk5ZTY3LTdhMjctNDY5MS05YzU1LWY4NmY0YjQ4MGFkOSIsImN1c3RvbWVyTmFtZSI6IkFjbWUgSW5jIiwiZmVhdHVyZXMiOlsiUHVsbE1vZGUiXSwiZXhwaXJhdGlvbkRhdGUiOiIyMDI0LTA3LTI1VDExOjU3OjIxLjk2MTYwOFoiLCJpc3N1ZWRBdCI6IjIwMjUtMDctMjVUMTE6NTc6MjEuOTYxNjA4WiJ9")
+		Expect(err).To(BeNil())
+		expiredSignature, err := base64.StdEncoding.DecodeString(
+			"Nk+Q3x/ZBg2DydTMcAhGzi8+xCBma4bsLfKXlN5f217/OqJVcfFDqlG3Q46nVRI92i/hOvXVAeEOnBpv8/0iDbUvSZB1fBilkyzglcH00hC7Y3CFF9CnxcmLlqWBl5ucL+MTmzCsgxMHhzklOF4oCMAAbigfty9xVCXE81rQN0jKPktZcVui15uubs7PVgXkvc7+NZrmmchXnECXz912S8ayllRWcgKL482xi8bf9XsKubg+mzQm/S4KvPBR1R8Yugnp1byyZmpzQmNMF1KYC5YT/vVqk7ojVZTPVG9y1SxnpFXGVO+4HRBnbEWoVnifg5U74FcU3kiIgOxpUoylsX88PCfZXdaJT5Mh65cZJVRx1RTYLgnBX260gzaLzuPF33uu5IZ1J182Si5RatkvNdPQd7mtLC2T/lyQK4gMqS2g0iidlxA2iwEeqC/UV42aeXrel3KRJ38TL0SNiCpMLly3ueC5sftdvRWARNel7aV/DAE+nfANIBO9YuLpiJY9EMndr1mpGclMZF6KbXkzOnEqbsiNmXANl7Y2lAKORWElC58IznD0WKFoFuc1ZltUDecGEFoExkdstrIPJ8HYi0dJ0OBaHfQNlo7MjEuHWkmZ1XoeUqMPxjFBrULlX74Lbowqif1lDnZhmZTTJs+qqGYLz424HtcVmir8UD5IboQ=")
+		Expect(err).To(BeNil())
+
+		secret := newLicenseSecret(licenseNamespace, expiredPayload, expiredSignature)
+		c := fake.NewClientBuilder().WithObjects(secret).Build()
+		reconciler := &controllers.SveltosClusterReconciler{
+			Client:           c,
+			Scheme:           scheme,
+			SveltosNamespace: licenseNamespace,
+		}
+
+		controllers.UpdateLicenseAnnotations(reconciler, context.TODO(), sveltosCluster, logger)
+
+		Expect(sveltosCluster.Annotations[license.LicensePayloadAnnotation]).ToNot(BeEmpty())
+		Expect(sveltosCluster.Annotations[license.LicenseSignatureAnnotation]).ToNot(BeEmpty())
+	})
+
+	It("clears stale annotations when no license secret is found", func() {
+		sveltosCluster.Annotations = map[string]string{
+			license.LicensePayloadAnnotation:   staleAnnotationValue,
+			license.LicenseSignatureAnnotation: staleAnnotationValue,
+		}
+
+		c := fake.NewClientBuilder().Build()
+		reconciler := &controllers.SveltosClusterReconciler{
+			Client:           c,
+			Scheme:           scheme,
+			SveltosNamespace: licenseNamespace,
+		}
+
+		controllers.UpdateLicenseAnnotations(reconciler, context.TODO(), sveltosCluster, logger)
+
+		Expect(sveltosCluster.Annotations).ToNot(HaveKey(license.LicensePayloadAnnotation))
+		Expect(sveltosCluster.Annotations).ToNot(HaveKey(license.LicenseSignatureAnnotation))
+	})
+
+	It("clears stale annotations when the signature no longer verifies", func() {
+		tamperedPayload := append(append([]byte{}, payloadData...), []byte("tampered")...)
+		secret := newLicenseSecret(licenseNamespace, tamperedPayload, signatureData)
+		c := fake.NewClientBuilder().WithObjects(secret).Build()
+		reconciler := &controllers.SveltosClusterReconciler{
+			Client:           c,
+			Scheme:           scheme,
+			SveltosNamespace: licenseNamespace,
+		}
+
+		sveltosCluster.Annotations = map[string]string{
+			license.LicensePayloadAnnotation:   staleAnnotationValue,
+			license.LicenseSignatureAnnotation: staleAnnotationValue,
+		}
+
+		controllers.UpdateLicenseAnnotations(reconciler, context.TODO(), sveltosCluster, logger)
+
+		Expect(sveltosCluster.Annotations).ToNot(HaveKey(license.LicensePayloadAnnotation))
+		Expect(sveltosCluster.Annotations).ToNot(HaveKey(license.LicenseSignatureAnnotation))
+	})
+
+	It("is a no-op when annotations already match the current license (avoids an unnecessary write)", func() {
+		secret := newLicenseSecret(licenseNamespace, payloadData, signatureData)
+		c := fake.NewClientBuilder().WithObjects(secret).Build()
+		reconciler := &controllers.SveltosClusterReconciler{
+			Client:           c,
+			Scheme:           scheme,
+			SveltosNamespace: licenseNamespace,
+		}
+
+		sveltosCluster.Annotations = map[string]string{
+			license.LicensePayloadAnnotation:   validLicenseDataB64,
+			license.LicenseSignatureAnnotation: validLicenseSignatureB64,
+		}
+		beforePtr := reflect.ValueOf(sveltosCluster.Annotations).Pointer()
+
+		controllers.UpdateLicenseAnnotations(reconciler, context.TODO(), sveltosCluster, logger)
+
+		Expect(sveltosCluster.Annotations[license.LicensePayloadAnnotation]).To(Equal(validLicenseDataB64))
+		Expect(sveltosCluster.Annotations[license.LicenseSignatureAnnotation]).To(Equal(validLicenseSignatureB64))
+		// Same underlying map: the function returned before ever writing to cluster.Annotations.
+		Expect(reflect.ValueOf(sveltosCluster.Annotations).Pointer()).To(Equal(beforePtr))
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.13.0
+	github.com/projectsveltos/libsveltos v1.13.1-0.20260730171509-41b249690865
 	github.com/prometheus/client_golang v1.24.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v1.13.0 h1:c5mV80T0s5dzW3c2xaEuWa3xISC85yGGoimau0c4bHA=
-github.com/projectsveltos/libsveltos v1.13.0/go.mod h1:TWOi1aZgpKGGI8lGdXhNE9Rnf3akS5bEVUuDV0EfmSo=
+github.com/projectsveltos/libsveltos v1.13.1-0.20260730171509-41b249690865 h1:DKfSfxhZ9r9EODFeBX2wUyB5ayS9uowPtybaABVJDdY=
+github.com/projectsveltos/libsveltos v1.13.1-0.20260730171509-41b249690865/go.mod h1:TWOi1aZgpKGGI8lGdXhNE9Rnf3akS5bEVUuDV0EfmSo=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltoscluster-manager:v1.13.0
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -192,7 +192,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltoscluster-manager:v1.13.0
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
`reconcilePullModeCluster` now verifies the sveltos-license Secret and relays its raw payload/signature bytes (base64-encoded) onto the corresponding `SveltosCluster`'s annotations.

sveltos-applier needs to verify the license itself.